### PR TITLE
Fix cache directory detection for PyInstaller builds

### DIFF
--- a/ch_career_mode/scanner.py
+++ b/ch_career_mode/scanner.py
@@ -3,6 +3,7 @@
 import configparser
 import os
 import sqlite3
+import sys
 from typing import Dict, List, Optional, Set, Tuple
 
 from PySide6.QtCore import QObject, Signal
@@ -13,8 +14,10 @@ PRIORITY = ["notes.chart", "notes.mid", "song.chart", "song.mid"]
 
 
 def _project_root() -> str:
-    """Return the absolute path to the repository root."""
+    """Return the absolute path to the repository root or executable directory."""
 
+    if getattr(sys, "frozen", False) and hasattr(sys, "executable"):
+        return os.path.dirname(os.path.abspath(sys.executable))
     return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 


### PR DESCRIPTION
## Summary
- adjust project root detection to use the executable directory when running from a PyInstaller bundle
- ensure the cache directory continues to be created relative to the project root in source builds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d425c137748332922cff5171e87af7