### PR TITLE
Parallelize song scanning

### DIFF
--- a/.codex/latest-session.md
+++ b/.codex/latest-session.md
@@ -1,21 +1,21 @@
 The most recent discussion I had with codex was the following. Please use these notes as informative context, so you can catch up and we can re-start the conversation accordingly.
 
-# Topic: Parallelizing the library scanner for faster multi-core performance
+# Topic: Increasing scanner concurrency for faster large-library scans
 
 ## User desires
-Improve Clone Hero library scanning performance on large collections without changing existing metadata, caching, or song ordering behavior.
+Improve Clone Hero library scanning performance on very large collections without altering metadata, caching, or ordering behavior.
 
 ## Specifics of user desires
-Introduce parallel processing so multiple song folders are scanned simultaneously while keeping SQLite writes safe, maintaining GUI responsiveness, and preserving current scoring, ordering, and caching semantics.
+Boost parallel processing within the scanner so more CPU cores are utilized (around 75% of available cores) while keeping SQLite writes safe, maintaining GUI responsiveness, and preserving existing scoring, ordering, and caching semantics.
 
 ## Actions taken
 - Added a thread pool in `ch_career_mode/scanner.py` to distribute folder scans across CPU cores while retaining the existing ScanWorker/QThread structure.
 - Created a helper to process individual song folders that mirrors the original metadata, MD5, and NPS parsing logic.
-- Batched SQLite writes on the main thread, preserved duplicate filtering order, and kept periodic GUI progress updates intact.
+- Tuned the scanner to size its thread pool dynamically at ~75% of detected CPU cores, with an opt-in override, while preserving batching, ordering, and UI update behavior.
 - Ran `python -m compileall ch_career_mode` to confirm the module compiles.
 
 ## Helpful hints about conversation & relevant code paths:
-- Parallel scanning logic lives in `ch_career_mode/scanner.py`, especially the new `_scan_song_folder` helper and updated `ScanWorker.run` implementation.
-- Thread pool size defaults to `min(8, os.cpu_count())` and results are re-ordered to match the original traversal before emitting to the GUI.
+- Parallel scanning logic lives in `ch_career_mode/scanner.py`, especially the `_scan_song_folder` helper and updated `ScanWorker.run` implementation.
+- Thread pool size now defaults to roughly 75% of detected CPU cores (minimum 1) unless an override is provided, and results are re-ordered to match the original traversal before emitting to the GUI.
 
 With this context in mind, I have a follow up query:


### PR DESCRIPTION
## Summary
- add a thread-pooled scanner helper so individual song folders are parsed off the main scan loop
- refactor `ScanWorker.run` to feed folders into the pool, batch SQLite writes, and preserve original ordering before emitting results
- refresh `.codex/latest-session.md` with notes from the current session

## Testing
- python -m compileall ch_career_mode

------
https://chatgpt.com/codex/tasks/task_e_68d445775e48833286582ea9a2d665a9