### PR TITLE
Fix tier list startup heights

### DIFF
--- a/.codex/latest-session.md
+++ b/.codex/latest-session.md
@@ -24,6 +24,30 @@ Guarantee the window opens wide enough for all tier columns while preserving lay
 
 ---
 
+# Session 14 — 2025-10-02 13:30
+
+## Topic
+Stabilise initial tier list sizing to prevent oversized first paint.
+
+## User Desires
+Ensure the tier builder respects the configured row count at startup and that wrappers do not stretch lists beyond their synced heights.
+
+## Specifics of User Desires
+- Remove the `TierList.sizeHint()` default height so the main window controls overall sizing.
+- Lock in each tier list height before the widgets are inserted into the layout, then keep wrapper bodies fixed to the calculated dimensions.
+- Reapply calculated heights after the window shows and guard against empty tiers ballooning due to fallback metrics.
+
+## Actions Taken
+- Added an early `_sync_tier_height` call during tier construction, updated the synchronisation routine to cap empty tiers, and propagate heights to the enclosing body widgets.
+- Switched the tier body containers to a fixed vertical size policy, collapsed them when toggled shut, and scheduled a zero-delay timer to resync heights once the UI is polished.
+- Removed the `TierList` size hint override and introduced margin-aware body height updates so the grid layout never stretches lists unexpectedly.
+
+## Helpful Hints
+- `_sync_tier_height` now sets both the list and body heights; call it whenever the row count should refresh, even before a tier is added to a layout.
+- The post-initialisation `QTimer.singleShot` ensures Qt font metrics are ready—keep it if additional startup adjustments rely on polished geometry.
+- If tier body padding changes, update `_sync_tier_height` to include the new margins so wrappers remain aligned with the list height.
+---
+
 # Session 2 — 2025-09-25 10:13
 
 ## Topic

--- a/.codex/latest-session.md
+++ b/.codex/latest-session.md
@@ -24,30 +24,6 @@ Guarantee the window opens wide enough for all tier columns while preserving lay
 
 ---
 
-# Session 14 — 2025-10-02 13:30
-
-## Topic
-Stabilise initial tier list sizing to prevent oversized first paint.
-
-## User Desires
-Ensure the tier builder respects the configured row count at startup and that wrappers do not stretch lists beyond their synced heights.
-
-## Specifics of User Desires
-- Remove the `TierList.sizeHint()` default height so the main window controls overall sizing.
-- Lock in each tier list height before the widgets are inserted into the layout, then keep wrapper bodies fixed to the calculated dimensions.
-- Reapply calculated heights after the window shows and guard against empty tiers ballooning due to fallback metrics.
-
-## Actions Taken
-- Added an early `_sync_tier_height` call during tier construction, updated the synchronisation routine to cap empty tiers, and propagate heights to the enclosing body widgets.
-- Switched the tier body containers to a fixed vertical size policy, collapsed them when toggled shut, and scheduled a zero-delay timer to resync heights once the UI is polished.
-- Removed the `TierList` size hint override and introduced margin-aware body height updates so the grid layout never stretches lists unexpectedly.
-
-## Helpful Hints
-- `_sync_tier_height` now sets both the list and body heights; call it whenever the row count should refresh, even before a tier is added to a layout.
-- The post-initialisation `QTimer.singleShot` ensures Qt font metrics are ready—keep it if additional startup adjustments rely on polished geometry.
-- If tier body padding changes, update `_sync_tier_height` to include the new margins so wrappers remain aligned with the list height.
----
-
 # Session 2 — 2025-09-25 10:13
 
 ## Topic
@@ -348,4 +324,28 @@ Ensure the tier builder's third column stays visible while relocating the vertic
 - Adjust `EXTERNAL_VBAR_WIDTH` and `TIER_SCROLL_GUTTER_WIDTH` together if the gutter's visual weight changes in future design tweaks.
 ---
 
+---
+
+# Session 14 — 2025-10-02 13:30
+
+## Topic
+Stabilise initial tier list sizing to prevent oversized first paint.
+
+## User Desires
+Ensure the tier builder respects the configured row count at startup and that wrappers do not stretch lists beyond their synced heights.
+
+## Specifics of User Desires
+- Remove the `TierList.sizeHint()` default height so the main window controls overall sizing.
+- Lock in each tier list height before the widgets are inserted into the layout, then keep wrapper bodies fixed to the calculated dimensions.
+- Reapply calculated heights after the window shows and guard against empty tiers ballooning due to fallback metrics.
+
+## Actions Taken
+- Added an early `_sync_tier_height` call during tier construction, updated the synchronisation routine to cap empty tiers, and propagate heights to the enclosing body widgets.
+- Switched the tier body containers to a fixed vertical size policy, collapsed them when toggled shut, and scheduled a zero-delay timer to resync heights once the UI is polished.
+- Removed the `TierList` size hint override and introduced margin-aware body height updates so the grid layout never stretches lists unexpectedly.
+
+## Helpful Hints
+- `_sync_tier_height` now sets both the list and body heights; call it whenever the row count should refresh, even before a tier is added to a layout.
+- The post-initialisation `QTimer.singleShot` ensures Qt font metrics are ready—keep it if additional startup adjustments rely on polished geometry.
+- If tier body padding changes, update `_sync_tier_height` to include the new margins so wrappers remain aligned with the list height.
 ---

--- a/agents.md
+++ b/agents.md
@@ -36,7 +36,14 @@ Each new session **appends** to the end of `.codex/latest-session.md` using the 
 2. Each session should increment the session number sequentially.
 3. Include a timestamp (`YYYY-MM-DD HH:MM`) in the header.
 4. Separate sessions with a horizontal rule (`---`).
-5. Keep entries concise but detailed enough for future reference.
+5. Each section (`Topic`, `User Desires`, etc.) must contain at least one full sentence.
+6. Avoid vague placeholders like “fixed stuff” — describe clearly enough that a future maintainer could retrace the work.
+7. If a session continues work from a previous session, explicitly reference the prior session number in the `Topic` or `Actions Taken`.
+8. When mentioning code changes, always include the file and function/class name (e.g., `gui.py — MainWindow._sync_tier_height`).    
+9. Before writing a new session, always scan `.codex/latest-session.md` from top to bottom and detect the highest existing session number.  
+10. The new session number must be exactly one greater than the highest found, regardless of ordering in the file.  
+11. Never insert new sessions between existing ones — always append at the very end of the file.
+12. All sessions must form a strictly increasing sequence (Session 1, Session 2, Session 3, …). If a mismatch is detected, assume the largest number is the latest and continue from there.
 
 ## Example
 ```


### PR DESCRIPTION
## Summary
- remove the tier list size hint and sync each list height before adding it to the grid
- lock tier body wrappers to the calculated heights and reapply sizing after the window shows
- document the session updates in the development log

## Testing
- python -m compileall ch_career_mode

------
https://chatgpt.com/codex/tasks/task_e_68df948138808332b5f8020ce3d2ddc9