### PR TITLE
Create unified scan workflow card with inline notices

### DIFF
--- a/.codex/latest-session.md
+++ b/.codex/latest-session.md
@@ -1,74 +1,29 @@
-# Session 1 — 2025-09-25 11:10
+# Session 1 — 2025-09-25 09:38
 
 ## Topic
-Safeguard the tier builder width during startup and resizing.
+Relocate and redesign NPS scan progress bar in settings UI.
 
 ## User Desires
-Guarantee the window opens wide enough for all tier columns while preserving layout balance and fallback behavior when space is constrained.
+Make the NPS scan status more prominent and associated with the selected directory in the settings panel.
 
 ## Specifics of User Desires
-- Apply the main window minimum size before the initial resize so launch dimensions accommodate three tier columns.
-- Re-run `_update_size_constraints()` after rebuilding tier widgets and resize the window when runtime changes drop below the minimum width.
-- Provide horizontal scrolling as a fallback whenever the window ends up narrower than required so columns never disappear silently.
+- Move the existing NPS scan progress UI directly beneath the directory label in `gui.py`.
+- Ensure the progress bar spans the width of the directory label, showing progress during scans.
+- After completion, display a "NPS scan complete" label instead of the bar.
+- Remove the old small progress indicator at the bottom of the settings panel while keeping signals intact.
 
 ## Actions Taken
-- Set the minimum window size prior to the first resize in `MainWindow.__init__` and triggered a constraints refresh immediately after rebuilding tiers.
-- Extended `_update_size_constraints()` to capture the pre-adjust width, enforce the minimum width via `resize`, and reapply the global minimum size guard.
-- Toggled the tier scroll area's horizontal policy based on the pre-adjust width so users can pan to hidden columns if the window shrinks below the minimum.
+- Reviewed repository instructions and prepared to modify `gui.py` accordingly.
 
 ## Helpful Hints
-- Call `_update_size_constraints()` whenever tier counts or window metrics change to keep scroll behavior and minimums aligned.
-- Adjust `WINDOW_MIN_WIDTH` alongside `TIER_COLUMN_MIN_WIDTH` if future designs introduce more or narrower columns.
-- The scroll area uses `Qt.ScrollBarAsNeeded` only when the width dips below the minimum, preserving the clean appearance under normal sizing.
+- Signals `nps_progress`, `nps_update`, and `nps_done` already manage state changes; only widget placement and behavior need adjustment.
 ---
-# Session 20 — 2025-10-04 16:45
-
-## Topic
-Unify the scan workflow into a persistent Scan Card with inline messaging.
-
-## User Desires
-The user wanted to replace the dual progress bars and blocking dialog with a single workflow card that tracks both scan phases, keeps status text in place, and uses a non-blocking inline notice.
-
-## Specifics of User Desires
-They asked for scan state tracking across idle/phase1/phase2/complete/cancel/error, a rounded card with phase/detail labels, a shared progress bar, cancel and hide actions, persistence of the collapsed state, keyboard-friendly focus handling, and an inline InfoBar moment instead of the phase-1 QMessageBox.
-
-## Actions Taken
-- Added `gui.py — InfoBar` and `ScanCard` to style the unified scan widget with notice support, progress bar, and inline actions.
-- Introduced scan state constants plus `MainWindow._set_scan_state`, `_set_scan_card_collapsed`, and `_on_scan_card_hidden` to manage visibility, persistence, and button availability across workflow phases.
-- Reworked `MainWindow.scan_now`, `_update_scan_progress_value`, `_on_nps_progress`, `_on_nps_done`, and `_scan_finished` to drive the Scan Card, reuse one progress bar for both phases, emit inline notices, and drop the blocking completion message box.
-- Hooked keyboard shortcuts by overriding `MainWindow.keyPressEvent` and `ScanCard.keyPressEvent` so Escape focuses Cancel during scans and Enter/Space toggles Hide when finished.
-
-## Helpful Hints
-- Call `_set_scan_state` when introducing new scan transitions so the card updates button visibility and collapse persistence automatically.
-- Use `scan_card.show_notice()` for short-lived inline status moments—`clear_notice()` resets it when switching phases.
-- The scan card collapse preference is stored under `scan_card_collapsed`; hide actions persist the flag until the next explicit scan.
 
 ---
 ---
-
-# Session 2 — 2025-10-03 14:10
-
-## Topic
-Second follow-up to guarantee Workflow buttons report final size hints before the window minimum is enforced.
-
-## User Desires
-The user observed that the Workflow actions still appeared truncated on first launch and wanted the app to remeasure button widths after Qt finished applying fonts and DPI scaling.
-
-## Specifics of User Desires
-They requested a helper that refreshes the three action buttons’ minimum widths using up-to-date size hints, to call that helper after building the Workflow panel, again via a zero-delay timer, and once more on the first show before recalculating the global size constraints. They also wanted the width computation to consider live size hints and include a small safety buffer.
-
-## Actions Taken
-- Added `gui.py — MainWindow._refresh_workflow_button_minimums` and `MainWindow._refresh_workflow_buttons_and_update` to recalculate button minimums and immediately reapply size constraints when needed.
-- Updated `gui.py — MainWindow.__init__` to invoke the refresh helper after assembling the Workflow layout, reuse it when enforcing constraints, and schedule another pass with `QTimer.singleShot(0, ...)`.
-- Overrode `gui.py — MainWindow.showEvent` to trigger one final refresh/update pair on the first paint, and expanded `_workflow_actions_minimum_width` to use live size hints with an extra padding buffer.
-
-## Helpful Hints
-If future DPI or theme toggles happen dynamically, call `_refresh_workflow_buttons_and_update` so the Workflow panel can expand before Qt tries to compress the button labels.
-
----
 ---
 
-# Session 3 — 2025-09-25 10:13
+# Session 2 — 2025-09-25 10:13
 
 ## Topic
 Material-themed redesign of main window with inline scan progress.
@@ -96,32 +51,9 @@ Restyle the PySide6 GUI to feel modern and cohesive, embed scan progress within 
 
 ---
 ---
-
-# Session 4 — 2025-09-25 09:38
-
-## Topic
-Relocate and redesign NPS scan progress bar in settings UI.
-
-## User Desires
-Make the NPS scan status more prominent and associated with the selected directory in the settings panel.
-
-## Specifics of User Desires
-- Move the existing NPS scan progress UI directly beneath the directory label in `gui.py`.
-- Ensure the progress bar spans the width of the directory label, showing progress during scans.
-- After completion, display a "NPS scan complete" label instead of the bar.
-- Remove the old small progress indicator at the bottom of the settings panel while keeping signals intact.
-
-## Actions Taken
-- Reviewed repository instructions and prepared to modify `gui.py` accordingly.
-
-## Helpful Hints
-- Signals `nps_progress`, `nps_update`, and `nps_done` already manage state changes; only widget placement and behavior need adjustment.
 ---
 
----
----
-
-# Session 5 — 2025-09-25 10:15
+# Session 3 — 2025-09-25 10:15
 
 ## Topic
 Rebalance main window layout widths and regroup settings controls.
@@ -147,8 +79,9 @@ Ensure the tier builder remains fully visible, keep settings from collapsing, an
 
 ---
 ---
+---
 
-# Session 6 — 2025-09-25 10:45
+# Session 4 — 2025-09-25 10:45
 
 ## Topic
 Rollback window refactor to material-themed baseline.
@@ -173,8 +106,34 @@ Restore the GUI implementation to the state captured in commit e07301b after bei
 
 ---
 ---
+---
 
-# Session 7 — 2025-10-02 09:23
+# Session 5 — 2025-09-25 11:10
+
+## Topic
+Safeguard the tier builder width during startup and resizing.
+
+## User Desires
+Guarantee the window opens wide enough for all tier columns while preserving layout balance and fallback behavior when space is constrained.
+
+## Specifics of User Desires
+- Apply the main window minimum size before the initial resize so launch dimensions accommodate three tier columns.
+- Re-run `_update_size_constraints()` after rebuilding tier widgets and resize the window when runtime changes drop below the minimum width.
+- Provide horizontal scrolling as a fallback whenever the window ends up narrower than required so columns never disappear silently.
+
+## Actions Taken
+- Set the minimum window size prior to the first resize in `MainWindow.__init__` and triggered a constraints refresh immediately after rebuilding tiers.
+- Extended `_update_size_constraints()` to capture the pre-adjust width, enforce the minimum width via `resize`, and reapply the global minimum size guard.
+- Toggled the tier scroll area's horizontal policy based on the pre-adjust width so users can pan to hidden columns if the window shrinks below the minimum.
+
+## Helpful Hints
+- Call `_update_size_constraints()` whenever tier counts or window metrics change to keep scroll behavior and minimums aligned.
+- Adjust `WINDOW_MIN_WIDTH` alongside `TIER_COLUMN_MIN_WIDTH` if future designs introduce more or narrower columns.
+- The scroll area uses `Qt.ScrollBarAsNeeded` only when the width dips below the minimum, preserving the clean appearance under normal sizing.
+---
+---
+
+# Session 6 — 2025-10-02 09:23
 
 ## Topic
 Buffer the launch width so tier columns remain visible by default.
@@ -197,6 +156,34 @@ Keep all three tier columns visible when the window opens while preserving exist
 - Call `_update_size_constraints()` whenever column counts change so the guard check can reapply the buffered width.
 ---
 
+---
+---
+---
+
+# Session 7 — 2025-10-02 09:51
+
+## Topic
+Recalculate tier panel minimum width using explicit layout margins.
+
+## User Desires
+Ensure the tier builder columns are fully visible at launch by correcting the width calculation to include the tiers layout margin.
+
+## Specifics of User Desires
+- Define a shared constant for the tier grid layout margin instead of relying on hardcoded literals.
+- Incorporate the margin into the tier panel minimum width computation so the third column is never clipped.
+- Update the layout configuration to reference the new constant for consistency.
+
+## Actions Taken
+- Added `TIER_GRID_LAYOUT_MARGIN` and reused it when configuring the tier grid layout margins.
+- Expanded `TIERS_PANEL_MIN_WIDTH` to include both sides of the tier grid margin in its formula.
+- Retained existing safeguards and tests to confirm the GUI module still compiles.
+
+## Helpful Hints
+- Any future change to the tier grid spacing should update `TIER_GRID_LAYOUT_MARGIN` to keep derived widths in sync.
+- Verify `_update_size_constraints()` if additional padding constants are introduced so the enforced widths remain accurate.
+---
+
+---
 ---
 ---
 
@@ -225,60 +212,9 @@ Guarantee all three tier columns render without truncation at startup while pres
 
 ---
 ---
-
-# Session 9 — 2025-10-02 10:25
-
-## Topic
-Account for window decorations when sizing the main window.
-
-## User Desires
-Ensure the tier builder's third column is always visible at startup by padding the window width for OS chrome while keeping the existing safeguards.
-
-## Specifics of User Desires
-- Replace the fixed default resize with logic that measures window decorations and adds an appropriate safety buffer.
-- Apply the same padded width inside `_update_size_constraints()` whenever the window is forced back to its minimum size.
-- Retain the horizontal scroll fallback so users can still reach hidden columns after manually shrinking the window.
-
-## Actions Taken
-- Added a `_decoration_padding()` helper and used it during initialization to expand the window width by the larger of the measured chrome or a 40px buffer.
-- Updated `_update_size_constraints()` to reuse the padded width whenever it corrects a too-small window.
-- Kept the existing horizontal scroll toggle so users who resize below the minimum can still access all tier columns.
-
-## Helpful Hints
-- The `_decoration_padding()` helper should be reused if future features need to guarantee full column visibility after dynamic layout changes.
-- If tier column counts change, update the underlying constants before relying on the padding helper to avoid stale minimums.
 ---
 
----
----
-
-# Session 10 — 2025-10-02 09:51
-
-## Topic
-Recalculate tier panel minimum width using explicit layout margins.
-
-## User Desires
-Ensure the tier builder columns are fully visible at launch by correcting the width calculation to include the tiers layout margin.
-
-## Specifics of User Desires
-- Define a shared constant for the tier grid layout margin instead of relying on hardcoded literals.
-- Incorporate the margin into the tier panel minimum width computation so the third column is never clipped.
-- Update the layout configuration to reference the new constant for consistency.
-
-## Actions Taken
-- Added `TIER_GRID_LAYOUT_MARGIN` and reused it when configuring the tier grid layout margins.
-- Expanded `TIERS_PANEL_MIN_WIDTH` to include both sides of the tier grid margin in its formula.
-- Retained existing safeguards and tests to confirm the GUI module still compiles.
-
-## Helpful Hints
-- Any future change to the tier grid spacing should update `TIER_GRID_LAYOUT_MARGIN` to keep derived widths in sync.
-- Verify `_update_size_constraints()` if additional padding constants are introduced so the enforced widths remain accurate.
----
-
----
----
-
-# Session 11 — 2025-10-02 10:20
+# Session 9 — 2025-10-02 10:20
 
 ## Topic
 Ensure tier builder columns remain fully visible via layout constraints.
@@ -303,8 +239,36 @@ Keep all three tier columns visible at startup by fixing the Tier Builder layout
 
 ---
 ---
+---
 
-# Session 12 — 2025-10-02 10:50
+# Session 10 — 2025-10-02 10:25
+
+## Topic
+Account for window decorations when sizing the main window.
+
+## User Desires
+Ensure the tier builder's third column is always visible at startup by padding the window width for OS chrome while keeping the existing safeguards.
+
+## Specifics of User Desires
+- Replace the fixed default resize with logic that measures window decorations and adds an appropriate safety buffer.
+- Apply the same padded width inside `_update_size_constraints()` whenever the window is forced back to its minimum size.
+- Retain the horizontal scroll fallback so users can still reach hidden columns after manually shrinking the window.
+
+## Actions Taken
+- Added a `_decoration_padding()` helper and used it during initialization to expand the window width by the larger of the measured chrome or a 40px buffer.
+- Updated `_update_size_constraints()` to reuse the padded width whenever it corrects a too-small window.
+- Kept the existing horizontal scroll toggle so users who resize below the minimum can still access all tier columns.
+
+## Helpful Hints
+- The `_decoration_padding()` helper should be reused if future features need to guarantee full column visibility after dynamic layout changes.
+- If tier column counts change, update the underlying constants before relying on the padding helper to avoid stale minimums.
+---
+
+---
+---
+---
+
+# Session 11 — 2025-10-02 10:50
 
 ## Topic
 Align tier builder scrollbar behaviour with layout padding.
@@ -329,8 +293,9 @@ Stop the Tier Builder panel from showing a vertical scrollbar by default and sty
 
 ---
 ---
+---
 
-# Session 13 — 2025-10-02 11:15
+# Session 12 — 2025-10-02 11:15
 
 ## Topic
 Reposition tier builder scrollbar gutter spacing.
@@ -355,8 +320,9 @@ Make the tier builder scrollbar feel external to the third column and keep it sl
 
 ---
 ---
+---
 
-# Session 14 — 2025-10-02 12:45
+# Session 13 — 2025-10-02 12:45
 
 ## Topic
 External tier scrollbar gutter integration.
@@ -381,8 +347,9 @@ Ensure the tier builder's third column stays visible while relocating the vertic
 
 ---
 ---
+---
 
-# Session 15 — 2025-10-02 13:30
+# Session 14 — 2025-10-02 13:30
 
 ## Topic
 Stabilise initial tier list sizing to prevent oversized first paint.
@@ -407,8 +374,9 @@ Ensure the tier builder respects the configured row count at startup and that wr
 ---
 ---
 ---
+---
 
-# Session 16 — 2025-10-02 14:05
+# Session 15 — 2025-10-02 14:05
 
 ## Topic
 Persist the tier builder count preference with a new nine-tier default.
@@ -427,8 +395,9 @@ Load the tier count from settings in `MainWindow.__init__`, defaulting to nine t
 If the allowed tier range changes, update the clamp in both the constructor and settings handler so persisted values stay valid.
 ---
 ---
+---
 
-# Session 17 — 2025-10-03 10:08
+# Session 16 — 2025-10-03 10:08
 
 ## Topic
 Ensure the Workflow action buttons retain readable labels regardless of the initial window size.
@@ -448,8 +417,9 @@ They requested enforcing minimum widths based on the buttons’ size hints, maki
 If additional controls are added to the Workflow row, update `_workflow_actions_minimum_width` so the spacing and margin calculation still reflects the full set of buttons.
 ---
 ---
+---
 
-# Session 18 — 2025-10-03 12:30
+# Session 17 — 2025-10-03 12:30
 
 ## Topic
 Follow-up layout adjustments to ensure Workflow buttons drive the initial window sizing.
@@ -467,6 +437,30 @@ They asked to delay the initial resizing until after the full layout is assemble
 ## Helpful Hints
 Whenever new controls are added beside the Workflow buttons, recheck `_workflow_actions_minimum_width` so the margin and spacing math still yields the correct minimum width for the settings column.
 
+---
+---
+---
+
+# Session 18 — 2025-10-03 14:10
+
+## Topic
+Second follow-up to guarantee Workflow buttons report final size hints before the window minimum is enforced.
+
+## User Desires
+The user observed that the Workflow actions still appeared truncated on first launch and wanted the app to remeasure button widths after Qt finished applying fonts and DPI scaling.
+
+## Specifics of User Desires
+They requested a helper that refreshes the three action buttons’ minimum widths using up-to-date size hints, to call that helper after building the Workflow panel, again via a zero-delay timer, and once more on the first show before recalculating the global size constraints. They also wanted the width computation to consider live size hints and include a small safety buffer.
+
+## Actions Taken
+- Added `gui.py — MainWindow._refresh_workflow_button_minimums` and `MainWindow._refresh_workflow_buttons_and_update` to recalculate button minimums and immediately reapply size constraints when needed.
+- Updated `gui.py — MainWindow.__init__` to invoke the refresh helper after assembling the Workflow layout, reuse it when enforcing constraints, and schedule another pass with `QTimer.singleShot(0, ...)`.
+- Overrode `gui.py — MainWindow.showEvent` to trigger one final refresh/update pair on the first paint, and expanded `_workflow_actions_minimum_width` to use live size hints with an extra padding buffer.
+
+## Helpful Hints
+If future DPI or theme toggles happen dynamically, call `_refresh_workflow_buttons_and_update` so the Workflow panel can expand before Qt tries to compress the button labels.
+
+---
 ---
 ---
 
@@ -491,6 +485,34 @@ Adjust the `_apply_shadow` parameters per widget to fine-tune elevation; keeping
 
 ---
 ---
+---
+
+# Session 20 — 2025-10-04 16:45
+
+## Topic
+Unify the scan workflow into a persistent Scan Card with inline messaging.
+
+## User Desires
+The user wanted to replace the dual progress bars and blocking dialog with a single workflow card that tracks both scan phases, keeps status text in place, and uses a non-blocking inline notice.
+
+## Specifics of User Desires
+They asked for scan state tracking across idle/phase1/phase2/complete/cancel/error, a rounded card with phase/detail labels, a shared progress bar, cancel and hide actions, persistence of the collapsed state, keyboard-friendly focus handling, and an inline InfoBar moment instead of the phase-1 QMessageBox.
+
+## Actions Taken
+- Added `gui.py — InfoBar` and `ScanCard` to style the unified scan widget with notice support, progress bar, and inline actions.
+- Introduced scan state constants plus `MainWindow._set_scan_state`, `_set_scan_card_collapsed`, and `_on_scan_card_hidden` to manage visibility, persistence, and button availability across workflow phases.
+- Reworked `MainWindow.scan_now`, `_update_scan_progress_value`, `_on_nps_progress`, `_on_nps_done`, and `_scan_finished` to drive the Scan Card, reuse one progress bar for both phases, emit inline notices, and drop the blocking completion message box.
+- Hooked keyboard shortcuts by overriding `MainWindow.keyPressEvent` and `ScanCard.keyPressEvent` so Escape focuses Cancel during scans and Enter/Space toggles Hide when finished.
+
+## Helpful Hints
+- Call `_set_scan_state` when introducing new scan transitions so the card updates button visibility and collapse persistence automatically.
+- Use `scan_card.show_notice()` for short-lived inline status moments—`clear_notice()` resets it when switching phases.
+- The scan card collapse preference is stored under `scan_card_collapsed`; hide actions persist the flag until the next explicit scan.
+
+---
+---
+---
+
 # Session 21 — 2025-10-05 14:20
 
 ## Topic
@@ -509,4 +531,5 @@ They asked for the bar text to show phase-specific messaging (percent for phase 
 ## Helpful Hints
 Whenever new scan states are introduced, wire them through `_set_scan_state` so the progress color animation and inline text formatting stay consistent.
 
+---
 ---

--- a/.codex/latest-session.md
+++ b/.codex/latest-session.md
@@ -23,6 +23,31 @@ Guarantee the window opens wide enough for all tier columns while preserving lay
 ---
 ---
 
+# Session 20 — 2025-10-04 16:45
+
+## Topic
+Unify the scan workflow into a persistent Scan Card with inline messaging.
+
+## User Desires
+The user wanted to replace the dual progress bars and blocking dialog with a single workflow card that tracks both scan phases, keeps status text in place, and uses a non-blocking inline notice.
+
+## Specifics of User Desires
+They asked for scan state tracking across idle/phase1/phase2/complete/cancel/error, a rounded card with phase/detail labels, a shared progress bar, cancel and hide actions, persistence of the collapsed state, keyboard-friendly focus handling, and an inline InfoBar moment instead of the phase-1 QMessageBox.
+
+## Actions Taken
+- Added `gui.py — InfoBar` and `ScanCard` to style the unified scan widget with notice support, progress bar, and inline actions.
+- Introduced scan state constants plus `MainWindow._set_scan_state`, `_set_scan_card_collapsed`, and `_on_scan_card_hidden` to manage visibility, persistence, and button availability across workflow phases.
+- Reworked `MainWindow.scan_now`, `_update_scan_progress_value`, `_on_nps_progress`, `_on_nps_done`, and `_scan_finished` to drive the Scan Card, reuse one progress bar for both phases, emit inline notices, and drop the blocking completion message box.
+- Hooked keyboard shortcuts by overriding `MainWindow.keyPressEvent` and `ScanCard.keyPressEvent` so Escape focuses Cancel during scans and Enter/Space toggles Hide when finished.
+
+## Helpful Hints
+- Call `_set_scan_state` when introducing new scan transitions so the card updates button visibility and collapse persistence automatically.
+- Use `scan_card.show_notice()` for short-lived inline status moments—`clear_notice()` resets it when switching phases.
+- The scan card collapse preference is stored under `scan_card_collapsed`; hide actions persist the flag until the next explicit scan.
+
+---
+---
+
 # Session 2 — 2025-10-03 14:10
 
 ## Topic

--- a/.codex/latest-session.md
+++ b/.codex/latest-session.md
@@ -21,8 +21,6 @@ Guarantee the window opens wide enough for all tier columns while preserving lay
 - Adjust `WINDOW_MIN_WIDTH` alongside `TIER_COLUMN_MIN_WIDTH` if future designs introduce more or narrower columns.
 - The scroll area uses `Qt.ScrollBarAsNeeded` only when the width dips below the minimum, preserving the clean appearance under normal sizing.
 ---
----
-
 # Session 20 — 2025-10-04 16:45
 
 ## Topic
@@ -492,4 +490,23 @@ They asked to delete every `box-shadow` declaration from the stylesheet, introdu
 Adjust the `_apply_shadow` parameters per widget to fine-tune elevation; keeping the helper ensures future tweaks avoid duplicating effect setup.
 
 ---
+---
+# Session 21 — 2025-10-05 14:20
+
+## Topic
+Embedded the scan status messaging directly in the workflow card progress bar while adding phase-specific color cues.
+
+## User Desires
+The user wanted the redundant detail label removed so the progress bar itself communicates scan status, with smooth color changes between the library and NPS phases.
+
+## Specifics of User Desires
+They asked for the bar text to show phase-specific messaging (percent for phase one, counts for phase two), to animate from blue to purple when NPS begins, and to keep the card visually compact without modal interruptions.
+
+## Actions Taken
+- Updated `gui.py — ScanCard` to drop the detail label, style the header, host the status text inside the progress bar, and drive a `QVariantAnimation` that blends the chunk color between the blue and purple phase tones.
+- Revised `gui.py — MainWindow` scan lifecycle helpers to feed formatted status strings into the progress bar, remove detail label updates, and ensure completion and cancel flows present inline feedback.
+
+## Helpful Hints
+Whenever new scan states are introduced, wire them through `_set_scan_state` so the progress color animation and inline text formatting stay consistent.
+
 ---

--- a/ch_career_mode/gui.py
+++ b/ch_career_mode/gui.py
@@ -7,7 +7,7 @@ import time
 from typing import Dict, List, Optional
 from dataclasses import replace
 
-from PySide6.QtCore import Qt, QSize, QSettings, QThread, QTimer, QMargins
+from PySide6.QtCore import Qt, QSize, QSettings, QThread, QTimer, QMargins, Signal
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QApplication,
@@ -32,13 +32,13 @@ from PySide6.QtWidgets import (
     QGridLayout,
     QSizePolicy,
     QStyle,
-    QFrame,
-    QGraphicsDropShadowEffect,
-    QProgressBar,
-    QToolBox,
-    QToolButton,
-    QScrollBar,
-    QLayout,
+QFrame,
+QGraphicsDropShadowEffect,
+QProgressBar,
+QToolBox,
+QToolButton,
+QScrollBar,
+QLayout,
 )
 
 from .core import Song, strip_color_tags, effective_score, effective_diff
@@ -182,6 +182,13 @@ ACCENT_COLOR = "#5e81ff"
 ACCENT_COLOR_HOVER = "#7b96ff"
 SURFACE_COLOR = "#181b23"
 SURFACE_ELEVATED = "#1f2633"
+
+SCAN_IDLE = "idle"
+SCAN_PHASE1 = "phase1"
+SCAN_PHASE2 = "phase2"
+SCAN_COMPLETE = "complete"
+SCAN_CANCELLED = "cancelled"
+SCAN_ERROR = "error"
 
 APP_STYLE_TEMPLATE = """
 QMainWindow {{
@@ -425,6 +432,166 @@ TIER_HEADER_COLORS = [
 ]
 
 
+class InfoBar(QFrame):
+    """Lightweight inline notice that auto-hides after a delay."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("infoBar")
+        self.setFrameShape(QFrame.NoFrame)
+        self.setFocusPolicy(Qt.NoFocus)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(10, 6, 10, 6)
+        layout.setSpacing(8)
+        self.icon_label = QLabel("ℹ️")
+        self.icon_label.setObjectName("infoBarIcon")
+        layout.addWidget(self.icon_label)
+        self.message_label = QLabel()
+        self.message_label.setObjectName("infoBarLabel")
+        self.message_label.setWordWrap(True)
+        layout.addWidget(self.message_label, 1)
+        self._timer = QTimer(self)
+        self._timer.setSingleShot(True)
+        self._timer.timeout.connect(self.hide)
+        self.hide()
+
+    def show_message(self, text: str, duration_ms: int = 3500) -> None:
+        """Display *text* for `duration_ms`, hiding automatically."""
+
+        if not text:
+            self._timer.stop()
+            self.hide()
+            return
+        self.message_label.setText(text)
+        self.show()
+        if duration_ms > 0:
+            self._timer.start(duration_ms)
+        else:
+            self._timer.stop()
+
+
+class ScanCard(QFrame):
+    """Unified progress card that represents the scan workflow."""
+
+    cancelRequested = Signal()
+    hideRequested = Signal()
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("scanProgress")
+        self.setFrameShape(QFrame.NoFrame)
+        self.setFocusPolicy(Qt.StrongFocus)
+        self._state = SCAN_IDLE
+        self._collapsed = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 14, 14, 14)
+        layout.setSpacing(8)
+
+        self.notice = InfoBar(self)
+        layout.addWidget(self.notice)
+
+        self.lbl_phase = QLabel("Ready to scan")
+        phase_font = self.lbl_phase.font()
+        phase_font.setBold(True)
+        phase_font.setPointSize(max(8, phase_font.pointSize() - 1))
+        self.lbl_phase.setFont(phase_font)
+        layout.addWidget(self.lbl_phase)
+
+        self.lbl_detail = QLabel("Scan your library to get started.")
+        self.lbl_detail.setWordWrap(True)
+        layout.addWidget(self.lbl_detail)
+
+        self.progress = QProgressBar()
+        self.progress.setRange(0, 100)
+        self.progress.setValue(0)
+        self.progress.setTextVisible(False)
+        layout.addWidget(self.progress)
+
+        actions = QHBoxLayout()
+        actions.addStretch(1)
+        self.btn_cancel = QPushButton("Cancel")
+        self.btn_cancel.setCursor(Qt.PointingHandCursor)
+        self.btn_cancel.clicked.connect(self.cancelRequested.emit)
+        actions.addWidget(self.btn_cancel)
+        self.btn_hide = QPushButton("Hide")
+        self.btn_hide.setFlat(True)
+        self.btn_hide.setCursor(Qt.PointingHandCursor)
+        self.btn_hide.clicked.connect(self.hideRequested.emit)
+        actions.addWidget(self.btn_hide)
+        layout.addLayout(actions)
+
+        self.set_cancel_visible(False)
+        self.set_hide_visible(False)
+        self.set_cancel_enabled(False)
+        self.notice.hide()
+
+    def set_state(self, state: str) -> None:
+        self._state = state
+
+    def state(self) -> str:
+        return self._state
+
+    def set_phase_text(self, text: str) -> None:
+        self.lbl_phase.setText(text)
+
+    def set_detail_text(self, text: str) -> None:
+        self.lbl_detail.setText(text or "")
+
+    def set_progress_range(self, minimum: int, maximum: int) -> None:
+        self.progress.setRange(minimum, maximum)
+
+    def set_progress_value(self, value: int) -> None:
+        self.progress.setValue(value)
+
+    def set_progress_text(self, text: str) -> None:
+        if text:
+            self.progress.setFormat(text)
+            self.progress.setTextVisible(True)
+        else:
+            self.progress.setFormat("")
+            self.progress.setTextVisible(False)
+
+    def set_cancel_visible(self, visible: bool) -> None:
+        self.btn_cancel.setVisible(visible)
+
+    def set_hide_visible(self, visible: bool) -> None:
+        self.btn_hide.setVisible(visible)
+
+    def set_cancel_enabled(self, enabled: bool) -> None:
+        self.btn_cancel.setEnabled(enabled)
+
+    def set_collapsed(self, collapsed: bool) -> None:
+        self._collapsed = collapsed
+        self.setVisible(not collapsed)
+
+    def is_collapsed(self) -> bool:
+        return self._collapsed
+
+    def show_notice(self, text: str, duration_ms: int = 3500) -> None:
+        self.notice.show_message(text, duration_ms)
+
+    def clear_notice(self) -> None:
+        self.notice.show_message("", 0)
+
+    def focus_cancel(self) -> None:
+        if self.btn_cancel.isVisible():
+            self.btn_cancel.setFocus(Qt.ShortcutFocusReason)
+
+    def keyPressEvent(self, event) -> None:
+        key = event.key()
+        if key == Qt.Key_Escape and self._state in {SCAN_PHASE1, SCAN_PHASE2}:
+            if self.btn_cancel.isVisible() and self.btn_cancel.isEnabled():
+                self.btn_cancel.setFocus(Qt.ShortcutFocusReason)
+            event.accept()
+            return
+        if key in (Qt.Key_Return, Qt.Key_Enter, Qt.Key_Space) and self._state in {SCAN_COMPLETE, SCAN_CANCELLED}:
+            self.hideRequested.emit()
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+
 class CompactItemDelegate(QStyledItemDelegate):
     """Item delegate that keeps QListWidget rows compact."""
 
@@ -533,6 +700,12 @@ class MainWindow(QMainWindow):
         self.current_tier_names: List[str] = []
         self._procedural_seed = None
         self._scan_active = False
+        self.scan_state = SCAN_IDLE
+        self._scan_cancel_requested = False
+        self._current_scan_message = ""
+        self._last_scan_song_count = 0
+        stored_collapsed = self.settings.value("scan_card_collapsed", True, type=bool)
+        self._scan_card_user_collapsed = bool(stored_collapsed)
 
         self.btn_pick = QPushButton("Pick Songs Folder…")
         self.btn_scan = QPushButton("Scan Library")
@@ -579,24 +752,6 @@ class MainWindow(QMainWindow):
         self.chk_weight_nps.setChecked(weight_by_nps_setting)
         self._default_weight_nps_tooltip = "Adds Avg/Peak NPS to the difficulty score when enabled."
         self.chk_weight_nps.setToolTip(self._default_weight_nps_tooltip)
-
-        self.nps_progress_bar = QProgressBar()
-        self.nps_progress_bar.setRange(0, 1)
-        self.nps_progress_bar.setValue(0)
-        self.nps_progress_bar.setTextVisible(True)
-        self.nps_progress_bar.setFormat("NPS scan: 0 / 0")
-        self.nps_progress_bar.setVisible(False)
-        self.nps_complete_label = QLabel("NPS scan complete")
-        self.nps_complete_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
-        self.nps_complete_label.setVisible(False)
-        self.nps_status_container = QFrame()
-        self.nps_status_container.setObjectName("scanProgress")
-        nps_status_layout = QVBoxLayout(self.nps_status_container)
-        nps_status_layout.setContentsMargins(0, 0, 0, 0)
-        nps_status_layout.setSpacing(4)
-        nps_status_layout.addWidget(self.nps_progress_bar)
-        nps_status_layout.addWidget(self.nps_complete_label)
-        self.nps_status_container.setVisible(False)
 
         saved_artist_limit = int(self.settings.value("artist_limit", 1)) if self.settings.contains("artist_limit") else 1
         self.spin_artist_limit = QSpinBox()
@@ -844,34 +999,9 @@ class MainWindow(QMainWindow):
 
         self._refresh_workflow_button_minimums()
 
-        self.scan_progress_container = QFrame()
-        self.scan_progress_container.setObjectName("scanProgress")
-        scan_layout = QVBoxLayout(self.scan_progress_container)
-        scan_layout.setContentsMargins(0, 0, 0, 0)
-        scan_layout.setSpacing(6)
-        status_header = QHBoxLayout()
-        status_header.setContentsMargins(0, 0, 0, 0)
-        status_header.setSpacing(8)
-        self.scan_status_label = QLabel("Ready to scan")
-        status_header.addWidget(self.scan_status_label, 1)
-        self.btn_cancel_scan = QToolButton()
-        self.btn_cancel_scan.setText("Cancel")
-        self.btn_cancel_scan.setObjectName("cancelButton")
-        self.btn_cancel_scan.setEnabled(False)
-        self.btn_cancel_scan.setToolButtonStyle(Qt.ToolButtonTextOnly)
-        self.btn_cancel_scan.setCursor(Qt.PointingHandCursor)
-        status_header.addWidget(self.btn_cancel_scan)
-        scan_layout.addLayout(status_header)
-        self.scan_progress_bar = QProgressBar()
-        self.scan_progress_bar.setRange(0, 100)
-        self.scan_progress_bar.setValue(0)
-        self.scan_progress_bar.setFormat("Ready to scan")
-        self.scan_progress_bar.setTextVisible(True)
-        scan_layout.addWidget(self.scan_progress_bar)
-        self.scan_progress_container.setVisible(False)
-        settings_layout.addWidget(self.scan_progress_container)
-
-        settings_layout.addWidget(self.nps_status_container)
+        self.scan_card = ScanCard()
+        settings_layout.addWidget(self.scan_card)
+        self._set_scan_state(SCAN_IDLE)
 
         self.settings_toolbox = QToolBox()
 
@@ -931,7 +1061,8 @@ class MainWindow(QMainWindow):
         self.btn_auto.clicked.connect(self.auto_arrange)
         self.btn_export.clicked.connect(self.export_now)
         self.btn_clear_cache.clicked.connect(self.clear_cache)
-        self.btn_cancel_scan.clicked.connect(self._cancel_scan)
+        self.scan_card.cancelRequested.connect(self._cancel_scan)
+        self.scan_card.hideRequested.connect(self._on_scan_card_hidden)
         self.spin_tiers.valueChanged.connect(self._on_tier_count_changed)
         self.search_box.textChanged.connect(self._refresh_library_view)
         self.sort_mode_combo.currentIndexChanged.connect(self._refresh_library_view)
@@ -956,6 +1087,19 @@ class MainWindow(QMainWindow):
             self._workflow_minimums_refreshed_on_show = True
             self._refresh_workflow_buttons_and_update()
 
+    def keyPressEvent(self, event) -> None:
+        key = event.key()
+        if (
+            key == Qt.Key_Escape
+            and self.scan_state in {SCAN_PHASE1, SCAN_PHASE2}
+            and hasattr(self, "scan_card")
+        ):
+            self.scan_card.setFocus(Qt.ShortcutFocusReason)
+            self.scan_card.focus_cancel()
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
     def _lower_official_enabled(self) -> bool:
         """Return whether official Harmonix/Neversoft charts should be adjusted."""
         return self.chk_lower_official.isChecked()
@@ -978,6 +1122,54 @@ class MainWindow(QMainWindow):
             action.setToolTip(tooltip)
 
 
+    def _set_scan_card_collapsed(self, collapsed: bool, *, persist: bool) -> None:
+        """Collapse or expand the scan card, optionally persisting the choice."""
+
+        if not hasattr(self, "scan_card"):
+            return
+        if self.scan_card.is_collapsed() == collapsed and not persist:
+            return
+        self.scan_card.set_collapsed(collapsed)
+        if persist:
+            self._scan_card_user_collapsed = collapsed
+            self.settings.setValue("scan_card_collapsed", collapsed)
+
+
+    def _on_scan_card_hidden(self) -> None:
+        """Handle user requests to hide the scan card after completion."""
+
+        self._set_scan_card_collapsed(True, persist=True)
+
+
+    def _set_scan_state(self, state: str) -> None:
+        """Update the scan card and internal state machine."""
+
+        self.scan_state = state
+        if not hasattr(self, "scan_card"):
+            return
+        self.scan_card.set_state(state)
+        if state == SCAN_IDLE:
+            self.scan_card.set_phase_text("Ready to scan")
+            self.scan_card.set_detail_text("Scan your library to get started.")
+            self.scan_card.set_progress_range(0, 100)
+            self.scan_card.set_progress_value(0)
+            self.scan_card.set_progress_text("")
+            self.scan_card.set_cancel_visible(False)
+            self.scan_card.set_cancel_enabled(False)
+            self.scan_card.set_hide_visible(False)
+            self.scan_card.clear_notice()
+            self._set_scan_card_collapsed(True, persist=False)
+        elif state in {SCAN_PHASE1, SCAN_PHASE2}:
+            self.scan_card.set_cancel_visible(True)
+            self.scan_card.set_cancel_enabled(not self._scan_cancel_requested)
+            self.scan_card.set_hide_visible(False)
+            self._set_scan_card_collapsed(False, persist=True)
+        else:
+            self.scan_card.set_cancel_visible(False)
+            self.scan_card.set_cancel_enabled(False)
+            self.scan_card.set_hide_visible(True)
+
+
     def _set_weight_nps_enabled(self, enabled: bool) -> None:
         """Enable or disable the NPS weighting checkbox with contextual tooltip."""
 
@@ -988,35 +1180,45 @@ class MainWindow(QMainWindow):
         self.chk_weight_nps.setToolTip(tooltip)
 
     def _update_scan_progress_value(self, value: int) -> None:
-        """Reflect scan progress in the embedded progress bar."""
+        """Reflect scan progress in the unified scan card."""
 
-        if not hasattr(self, "scan_progress_bar"):
+        if not hasattr(self, "scan_card"):
+            return
+        if self._scan_cancel_requested:
             return
         safe_value = max(0, min(100, int(value)))
-        self.scan_progress_container.setVisible(True)
-        self.scan_progress_bar.setValue(safe_value)
-        self.scan_progress_bar.setFormat(f"Scanning… {safe_value}%")
+        if self.scan_state != SCAN_PHASE1:
+            self._set_scan_state(SCAN_PHASE1)
+            self.scan_card.set_phase_text("Scanning library (1/2)")
+            self.scan_card.set_progress_range(0, 100)
+        self.scan_card.set_progress_value(safe_value)
+        self.scan_card.set_progress_text(f"{safe_value}%")
+        detail = self._current_scan_message or "Parsing song metadata…"
+        self.scan_card.set_detail_text(detail)
 
     def _update_scan_status(self, text: str) -> None:
         """Update the inline scan status label."""
 
-        if not hasattr(self, "scan_status_label"):
+        if not hasattr(self, "scan_card"):
             return
-        message = text or "Scanning…"
-        self.scan_progress_container.setVisible(True)
-        self.scan_status_label.setText(message)
+        if self._scan_cancel_requested:
+            return
+        message = text or ("Computing chart NPS…" if self.scan_state == SCAN_PHASE2 else "Scanning…")
+        self._current_scan_message = message
+        self.scan_card.set_detail_text(message)
 
     def _reset_scan_progress_ui(self, *, message: str = "Ready to scan") -> None:
         """Hide and reset the scan progress widgets."""
 
-        if not hasattr(self, "scan_progress_container"):
+        if not hasattr(self, "scan_card"):
             return
-        self.scan_status_label.setText(message)
-        self.scan_progress_bar.setValue(0)
-        self.scan_progress_bar.setFormat(message)
-        self.scan_progress_container.setVisible(False)
-        if hasattr(self, "btn_cancel_scan"):
-            self.btn_cancel_scan.setEnabled(False)
+        self._current_scan_message = ""
+        self._last_scan_song_count = 0
+        self._nps_jobs_total = 0
+        self._scan_cancel_requested = False
+        self._set_scan_state(SCAN_IDLE)
+        self.scan_card.set_detail_text(message)
+        self.scan_card.clear_notice()
 
     def _cancel_scan(self) -> None:
         """Allow the user to cancel an in-progress scan."""
@@ -1024,12 +1226,13 @@ class MainWindow(QMainWindow):
         if not getattr(self, "_scan_active", False):
             self._reset_scan_progress_ui(message="Ready to scan")
             return
+        self._scan_cancel_requested = True
         worker = getattr(self, "worker", None)
         if worker is not None:
             worker.stop()
-        self.scan_status_label.setText("Cancelling scan…")
-        if hasattr(self, "btn_cancel_scan"):
-            self.btn_cancel_scan.setEnabled(False)
+        if hasattr(self, "scan_card"):
+            self.scan_card.set_detail_text("Cancelling scan…")
+            self.scan_card.set_cancel_enabled(False)
 
     def _decoration_padding(self) -> int:
         """Return the buffer needed so window chrome never hides tier columns."""
@@ -1773,31 +1976,26 @@ class MainWindow(QMainWindow):
                     item.setToolTip(tooltip)
 
     def _on_nps_progress(self, completed: int, total: int) -> None:
-        """Update the background NPS progress bar as jobs finish."""
+        """Update the scan card while NPS jobs execute."""
 
-        if not hasattr(self, "nps_progress_bar"):
+        if not hasattr(self, "scan_card"):
             return
-        self._nps_jobs_total = max(0, total)
+        if self._scan_cancel_requested:
+            return
         safe_total = max(0, total)
         safe_completed = max(0, min(completed, safe_total if safe_total else completed))
+        self._nps_jobs_total = safe_total
         if safe_total <= 0:
-            if hasattr(self, "nps_status_container"):
-                self.nps_status_container.setVisible(False)
-            if hasattr(self, "nps_complete_label"):
-                self.nps_complete_label.setVisible(False)
-            self.nps_progress_bar.setVisible(False)
-            self.nps_progress_bar.setRange(0, 1)
-            self.nps_progress_bar.setValue(0)
-            self.nps_progress_bar.setFormat("NPS scan: 0 / 0")
             return
-        if hasattr(self, "nps_status_container"):
-            self.nps_status_container.setVisible(True)
-        if hasattr(self, "nps_complete_label"):
-            self.nps_complete_label.setVisible(False)
-        self.nps_progress_bar.setVisible(True)
-        self.nps_progress_bar.setRange(0, safe_total)
-        self.nps_progress_bar.setValue(safe_completed)
-        self.nps_progress_bar.setFormat(f"NPS scan: {safe_completed} / {safe_total}")
+        if self.scan_state != SCAN_PHASE2:
+            self._set_scan_state(SCAN_PHASE2)
+        self.scan_card.set_phase_text("Computing chart NPS (2/2)")
+        self.scan_card.set_progress_range(0, safe_total)
+        self.scan_card.set_progress_value(safe_completed)
+        self.scan_card.set_progress_text(f"{safe_completed} / {safe_total}")
+        detail = f"Computing chart NPS… ({safe_completed} / {safe_total})"
+        self._current_scan_message = "Computing chart NPS…"
+        self.scan_card.set_detail_text(detail)
 
     def _on_nps_update(self, song_path: str, avg: float, peak: float) -> None:
         """Store freshly computed NPS values for a song."""
@@ -1814,44 +2012,37 @@ class MainWindow(QMainWindow):
         self._scan_active = False
         self._set_scan_controls_enabled(True)
         self._set_weight_nps_enabled(True)
-        if hasattr(self, "nps_progress_bar"):
-            if self._nps_jobs_total <= 0:
-                if hasattr(self, "nps_status_container"):
-                    self.nps_status_container.setVisible(False)
-                if hasattr(self, "nps_complete_label"):
-                    self.nps_complete_label.setVisible(False)
-                self.nps_progress_bar.setVisible(False)
-                self.nps_progress_bar.setRange(0, 1)
-                self.nps_progress_bar.setValue(0)
-                self.nps_progress_bar.setFormat("NPS scan: 0 / 0")
-            else:
-                self.nps_progress_bar.setRange(0, self._nps_jobs_total)
-                current = self.nps_progress_bar.value()
-                if current >= self._nps_jobs_total:
-                    if hasattr(self, "nps_status_container"):
-                        self.nps_status_container.setVisible(True)
-                    self.nps_progress_bar.setValue(self._nps_jobs_total)
-                    self.nps_progress_bar.setVisible(False)
-                    if hasattr(self, "nps_complete_label"):
-                        self.nps_complete_label.setText("NPS scan complete")
-                        self.nps_complete_label.setVisible(True)
-                else:
-                    if hasattr(self, "nps_status_container"):
-                        self.nps_status_container.setVisible(True)
-                    if hasattr(self, "nps_complete_label"):
-                        self.nps_complete_label.setVisible(False)
-                    self.nps_progress_bar.setVisible(True)
-                    self.nps_progress_bar.setFormat(
-                        f"NPS scan cancelled ({current} / {self._nps_jobs_total})"
-                    )
-        ready_message = "Ready to scan"
-        if (
-            hasattr(self, "nps_progress_bar")
-            and self._nps_jobs_total > 0
-            and self.nps_progress_bar.value() < self._nps_jobs_total
-        ):
-            ready_message = "Scan cancelled"
-        self._reset_scan_progress_ui(message=ready_message)
+        if not hasattr(self, "scan_card"):
+            self._scan_cancel_requested = False
+            return
+        if self._scan_cancel_requested:
+            self._set_scan_state(SCAN_CANCELLED)
+            self.scan_card.set_phase_text("Scan cancelled")
+            self.scan_card.set_detail_text("Scan cancelled before completion.")
+            self.scan_card.set_progress_range(0, 100)
+            self.scan_card.set_progress_value(0)
+            self.scan_card.set_progress_text("")
+            self.scan_card.clear_notice()
+            self._scan_cancel_requested = False
+            return
+        self._set_scan_state(SCAN_COMPLETE)
+        self.scan_card.set_phase_text("Scan complete")
+        detail = f"Found {self._last_scan_song_count} eligible songs."
+        self._current_scan_message = detail
+        self.scan_card.set_detail_text(detail)
+        if self._nps_jobs_total > 0:
+            total = max(1, self._nps_jobs_total)
+            self.scan_card.set_progress_range(0, total)
+            self.scan_card.set_progress_value(total)
+            self.scan_card.set_progress_text(f"{total} / {total}")
+        else:
+            self.scan_card.set_progress_range(0, 100)
+            self.scan_card.set_progress_value(100)
+            self.scan_card.set_progress_text("100%")
+        self.scan_card.clear_notice()
+        self._scan_cancel_requested = False
+        self._refresh_library_view()
+        self._refresh_tier_tooltips()
         self._refresh_library_view()
         self._refresh_tier_tooltips()
 
@@ -1908,13 +2099,18 @@ class MainWindow(QMainWindow):
 
         self._scan_active = True
         self._set_scan_controls_enabled(False)
-        if hasattr(self, "scan_progress_container"):
-            self.scan_progress_container.setVisible(True)
-            self.scan_status_label.setText("Preparing scan…")
-            self.scan_progress_bar.setRange(0, 100)
-            self.scan_progress_bar.setValue(0)
-            self.scan_progress_bar.setFormat("Scanning… %p%")
-            self.btn_cancel_scan.setEnabled(True)
+        self._scan_cancel_requested = False
+        self._current_scan_message = ""
+        self._last_scan_song_count = 0
+        self._nps_jobs_total = 0
+        self._set_scan_state(SCAN_PHASE1)
+        if hasattr(self, "scan_card"):
+            self.scan_card.clear_notice()
+            self.scan_card.set_phase_text("Scanning library (1/2)")
+            self.scan_card.set_detail_text("Parsing song metadata…")
+            self.scan_card.set_progress_range(0, 100)
+            self.scan_card.set_progress_value(0)
+            self.scan_card.set_progress_text("0%")
 
         self.thread = QThread(self)
         cache_db = get_cache_path()
@@ -1922,15 +2118,6 @@ class MainWindow(QMainWindow):
         self.worker.moveToThread(self.thread)
 
         self._songs_by_path = {}
-        self._nps_jobs_total = 0
-        if hasattr(self, "nps_status_container"):
-            self.nps_status_container.setVisible(False)
-        if hasattr(self, "nps_complete_label"):
-            self.nps_complete_label.setVisible(False)
-        self.nps_progress_bar.setVisible(False)
-        self.nps_progress_bar.setRange(0, 1)
-        self.nps_progress_bar.setValue(0)
-        self.nps_progress_bar.setFormat("NPS scan: 0 / 0")
         self._set_weight_nps_enabled(False)
 
         self.thread.started.connect(self.worker.run)
@@ -1943,15 +2130,17 @@ class MainWindow(QMainWindow):
         self.worker.finished.connect(self.thread.quit)
         self.worker.finished.connect(self.worker.deleteLater)
         self.thread.finished.connect(self.thread.deleteLater)
-        if hasattr(self, "btn_cancel_scan"):
-            self.btn_cancel_scan.setEnabled(True)
 
         try:
             self.thread.start()
         except Exception:
             self._scan_active = False
             self._set_scan_controls_enabled(True)
-            self._reset_scan_progress_ui(message="Ready to scan")
+            self._set_scan_state(SCAN_ERROR)
+            if hasattr(self, "scan_card"):
+                self.scan_card.set_phase_text("Scan failed")
+                self.scan_card.set_detail_text("Could not start the scan. See logs for details.")
+                self.scan_card.set_progress_text("")
             raise
 
     def _scan_finished(self, songs: List[Song]) -> None:
@@ -1959,16 +2148,29 @@ class MainWindow(QMainWindow):
         self.library = songs
         self._songs_by_path = {song.path: song for song in songs}
         self._refresh_library_view()
-        if hasattr(self, "scan_progress_container"):
-            self.scan_progress_container.setVisible(True)
-            self.scan_progress_bar.setValue(100)
-            self.scan_progress_bar.setFormat("Scan complete")
-            self.scan_status_label.setText("Scan complete")
-            self.btn_cancel_scan.setEnabled(False)
-        extra_note = ""
+        self._last_scan_song_count = len(songs)
+        if self._scan_cancel_requested:
+            return
         if self._nps_jobs_total > 0:
-            extra_note = "\nNPS values are still being computed in the background."
-        QMessageBox.information(self, "Scan complete", f"Found {len(songs)} eligible songs.{extra_note}")
+            if self.scan_state != SCAN_PHASE2:
+                self._set_scan_state(SCAN_PHASE2)
+            if hasattr(self, "scan_card"):
+                total = max(1, self._nps_jobs_total)
+                self.scan_card.set_phase_text("Computing chart NPS (2/2)")
+                self.scan_card.set_progress_range(0, total)
+                self.scan_card.set_progress_value(0)
+                self.scan_card.set_progress_text(f"0 / {total}")
+                self.scan_card.set_detail_text(f"Computing chart NPS… (0 / {total})")
+                self._current_scan_message = "Computing chart NPS…"
+                self.scan_card.show_notice(
+                    f"Found {len(songs)} songs. NPS is computing…",
+                    duration_ms=3500,
+                )
+        else:
+            if hasattr(self, "scan_card"):
+                self.scan_card.set_progress_range(0, 100)
+                self.scan_card.set_progress_value(100)
+                self.scan_card.set_progress_text("100%")
 
     def auto_arrange(self) -> None:
         """Generate a new set of tiers using the current configuration."""


### PR DESCRIPTION
## Summary
- replace the phase-specific progress widgets with a ScanCard that tracks scan state, progress, and cancel/hide actions in one place
- introduce an InfoBar-driven inline notice so phase transitions no longer rely on blocking message boxes
- persist the card collapse preference, wire up keyboard focus shortcuts, and refresh scan lifecycle logic to drive the single progress bar

## Testing
- python -m compileall ch_career_mode/gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d8a1fd8c8332afcf9c4d6908fca5