### PR TITLE
Keep Filters controls visible at minimum window width

### DIFF
--- a/.codex/latest-session.md
+++ b/.codex/latest-session.md
@@ -892,3 +892,23 @@ They asked for a helper that standardizes label sizing, an updated settings mini
 When introducing new Filters controls, create their labels through `_create_filters_label` and remember to refresh widths plus `_update_size_constraints()` so the column keeps honoring the reserved space.
 
 ---
+# Session 40 — 2025-10-11 15:10
+
+## Topic
+Expanded the Filters label helper to adapt to the widest caption so layout stays in one row.
+
+## User Desires
+The user wanted the Filters captions to remain fully visible beside their spin boxes without wrapping under the controls.
+
+## Specifics of User Desires
+They asked for `_create_filters_label` to track every caption, grow the cached width when encountering longer text, and immediately apply the wider minimum to all labels while refreshing size constraints.
+
+## Actions Taken
+- Updated `gui.py — MainWindow._create_filters_label` to store every Filters label, recalculate the cached width using font metrics, and propagate new minimum widths across the column.
+- Triggered `_update_size_constraints()` whenever the cached Filters label width increases so the settings card minimum reflects the expanded column.
+- Re-ran `python -m compileall ch_career_mode` to ensure the module remains syntactically valid after the helper changes.
+
+## Helpful Hints
+When adding future Filters captions, `_create_filters_label` will automatically widen the column as needed and re-evaluate the overall settings minimum, so reuse it for consistent alignment.
+
+---

--- a/.codex/latest-session.md
+++ b/.codex/latest-session.md
@@ -869,3 +869,26 @@ They asked for a shared Filters spin box width baseline plus a helper that recal
 Whenever Filters spin box content changes, call `_refresh_spinbox_width` to sync the control’s minimum width with the new size hint so future style tweaks (like padding) cannot reintroduce truncation.
 
 ---
+
+---
+
+# Session 39 — 2025-10-11 14:30
+
+## Topic
+Reinforced the Filters column sizing so captions and controls stay readable at minimum widths.
+
+## User Desires
+The user wanted the Filters labels to share a consistent width while keeping longer suffixes like "30 seconds" and "110 minutes" fully visible without manual resizing.
+
+## Specifics of User Desires
+They asked for a helper that standardizes label sizing, an updated settings minimum that respects the Filters form geometry, and automatic width recalculations whenever the spin boxes change units.
+
+## Actions Taken
+- Added `_create_filters_label` and a stored font-metric width in `gui.py — MainWindow.__init__` so Filters captions align and keep their column from collapsing.
+- Extended `gui.py — MainWindow._update_size_constraints` to include Filters label, spacing, margin, and spin box requirements when enforcing the settings card minimum.
+- Triggered `_update_size_constraints()` after every Filters `_refresh_spinbox_width` call, including the unit toggle logic in `_set_short_song_spinbox_display_from_seconds`.
+
+## Helpful Hints
+When introducing new Filters controls, create their labels through `_create_filters_label` and remember to refresh widths plus `_update_size_constraints()` so the column keeps honoring the reserved space.
+
+---

--- a/ch_career_mode/gui.py
+++ b/ch_career_mode/gui.py
@@ -1782,13 +1782,25 @@ class MainWindow(QMainWindow):
     def _create_filters_label(self, text: str) -> QLabel:
         """Return a Filters label sized to preserve the column width."""
 
+        if not hasattr(self, "_filters_labels"):
+            self._filters_labels: List[QLabel] = []
+
         label = QLabel(text)
-        width = getattr(self, "_filters_label_min_width", 0)
-        if width <= 0:
-            width = self.fontMetrics().horizontalAdvance("Exclude charts longer than:")
-            self._filters_label_min_width = width
-        label.setMinimumWidth(max(0, width))
         label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+
+        current_width = max(0, getattr(self, "_filters_label_min_width", 0))
+        text_width = self.fontMetrics().horizontalAdvance(text)
+        new_width = max(current_width, text_width)
+        width_changed = new_width != current_width
+        self._filters_label_min_width = new_width
+
+        self._filters_labels.append(label)
+        for stored_label in self._filters_labels:
+            stored_label.setMinimumWidth(new_width)
+
+        if width_changed:
+            self._update_size_constraints()
+
         return label
 
     def _refresh_spinbox_width(


### PR DESCRIPTION
## Summary
- reserve a shared minimum width for Filters labels via a helper so the column stays aligned
- recompute the settings card minimum using the Filters form label width, spin boxes, spacing, and margins
- trigger size constraint updates whenever Filters spin boxes recalculate their minimum width

## Testing
- python -m compileall ch_career_mode

------
https://chatgpt.com/codex/tasks/task_e_68edfd4933e08332b9eb01dd26763a7c